### PR TITLE
change from gres:gpu to gres/gpu

### DIFF
--- a/slurm_gpustat.py
+++ b/slurm_gpustat.py
@@ -623,7 +623,9 @@ def gpu_usage(resources: dict, partition: Optional[str] = None) -> dict:
        resource_flag = "gres"
     else:
        resource_flag = "tres-per-node"
-    if int(slurm_version[0:2]) >= 21:
+    if int(slurm_version[0:2]) >= 23:
+        gpu_identifier = 'gres/gpu'
+    elif int(slurm_version[0:2]) >= 21:
         gpu_identifier = 'gres:gpu'
     else:
         gpu_identifier = 'gpu'


### PR DESCRIPTION
Not sure in what version, but when running squeue:
https://github.com/orena1/slurm_web/blob/70d1b3291ecc02a089941b0b5be0eff105e58688/slurm_gpustat.py#L633
we get back gres/gpu and not gres:gpu